### PR TITLE
Rerender navbar on route changes

### DIFF
--- a/client/src/components/AuthService.js
+++ b/client/src/components/AuthService.js
@@ -55,7 +55,4 @@ export default class AuthService {
         // this will reload the page and reset the state of the application
         window.location.reload('/');
     }
-
-
-
 }

--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -3,13 +3,35 @@ import { Link } from 'react-router-dom';
 import AuthService from '../AuthService';
 
 class Navbar extends Component {
+    state = {
+        isLoggedIn: false
+    };
+
+    historyUnListen = null;
+
     constructor() {
         super();
         this.Auth = new AuthService();
     }
 
+    componentDidMount() {
+        this.setState({ isLoggedIn: this.Auth.loggedIn() })
+        this.historyListener = this.props.history.listen(this.onHistoryChange)
+    }
+
+    onHistoryChange = () => {
+        if (this.Auth.loggedIn() !== this.state.isLoggedIn) {
+            this.setState({ isLoggedIn: this.Auth.loggedIn() });
+        }
+    }
+
+    componentWillUnmount() {
+        // unsubscribe to history changes
+        this.historyUnListen && this.historyUnListen()
+    }
+
     showNavigation = () => {
-        if (this.Auth.loggedIn()) {
+        if (this.state.isLoggedIn) {
             return (
                 <ul className="navbar-nav">
                     <li className="nav-item">

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -22,7 +22,8 @@ if(localStorage.getItem("id_token")) {
 ReactDOM.render(
     <Router>
         <div>
-            <Navbar />
+            {/* Navbar needs history prop from router */}
+            <Route path="/" component={Navbar} />
             <Route exact path="/" component={App} />
             <Route exact path="/login" component={Login} />
             <Route exact path="/signup" component={Signup} />


### PR DESCRIPTION
This commit adds changes in order to update the Navbar when
the user's login state changes.

I believe a better approach would be to add an observer for changes
in the Auth state and pass that as a singleton to components that
should update when the Auth state changes. However, implementing
this change would require changes in several components.

This change updates only the Navbar and /client/src/index.js by
modifying the Navbar so that it listens for changes in the history
prop injected by BrowserRouter and updating the Navbar component
if the Auth state has changed.